### PR TITLE
Refactor extension naming and update linter rules

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -22,9 +22,6 @@ linter:
   # producing the lint.
   rules:
     constant_identifier_names: false
-    camel_case_extensions: false
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
 
 # Additional information about this file can be found at
 # https://dart.dev/tools/analysis

--- a/lib/src/call_directory/call_directory_extension.dart
+++ b/lib/src/call_directory/call_directory_extension.dart
@@ -25,7 +25,7 @@ part of 'package:flutter_callkit_voximplant/flutter_callkit_voximplant.dart';
 ///   functions that access numbers storage.
 ///
 /// See [example]() for an example of realisation and architecture details.
-extension FCXPlugin_CallDirectoryExtension on FCXPlugin {
+extension FCXPluginCallDirectoryExtension on FCXPlugin {
   /// Invokes `FlutterCallkitPlugin.getBlockedPhoneNumbers` property
   /// in the native iOS code and returns the list of blocked phone numbers.
   ///

--- a/lib/src/call_directory/call_directory_phone_number.dart
+++ b/lib/src/call_directory/call_directory_phone_number.dart
@@ -7,7 +7,7 @@ part of 'package:flutter_callkit_voximplant/flutter_callkit_voximplant.dart';
 ///
 /// Represents a phone number that might be blocked.
 ///
-/// Used in [FCXPlugin_CallDirectoryExtension].
+/// Used in [FCXPluginCallDirectoryExtension].
 @immutable
 class FCXCallDirectoryPhoneNumber {
   /// The phone number.

--- a/lib/src/call_directory/identifiable_phone_number.dart
+++ b/lib/src/call_directory/identifiable_phone_number.dart
@@ -6,7 +6,7 @@ part of 'package:flutter_callkit_voximplant/flutter_callkit_voximplant.dart';
 ///
 /// Represents a phone number that might be blocked or identified.
 ///
-/// Used in [FCXPlugin_CallDirectoryExtension].
+/// Used in [FCXPluginCallDirectoryExtension].
 @immutable
 class FCXIdentifiablePhoneNumber extends FCXCallDirectoryPhoneNumber {
   /// The identification label of the phone number.


### PR DESCRIPTION
- Rename `FCXPlugin_CallDirectoryExtension` to `FCXPluginCallDirectoryExtension`.
- Remove `camel_case_extensions` from linter rules.